### PR TITLE
Fix CXX standard so that SFML can compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.18.0)
 
-set(CMAKE_CXX_STANDARD 20)
-
 project("carise")
 
 option(CARISE_USE_PCH "Use precompiled headers" ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+set(CMAKE_CXX_STANDARD 23)
+
 add_executable(${PROJECT_NAME}
   "main.cpp"
 )

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,5 +1,7 @@
 include(FetchContent)
 
+set(CMAKE_CXX_STANDARD 14)
+
 set(BUILD_SHARED_LIBS OFF)
 FetchContent_Declare(sfml
   GIT_REPOSITORY https://github.com/SFML/SFML


### PR DESCRIPTION
SFML does not compile with cpp standards higher than C++14, as the library uses `std::auto_ptr`s, which were already deprecated in C++11. Therefore, I removed the `CMAKE_CXX_STANDARD` variable from the main `CMakeLists.txt` to have each subdirectory have their own standard, so that SFML may still get compiled and our main project can still benefit from the features of C++23.